### PR TITLE
Fix text filter nested array bug

### DIFF
--- a/assets/js/apps/search/components/filters/text-filter/TextFilter.jsx
+++ b/assets/js/apps/search/components/filters/text-filter/TextFilter.jsx
@@ -11,7 +11,7 @@ const _getValueContent = (value) => {
             // If this is an exact match filter,
             // the value would be the first array element of content. 
             // This is because an "IS" operator filter
-            // uses filters for values.
+            // uses an array for value.
             return value.content[0];
         } else if (value.op === "contains") {
             // If this is a fuzzy match filter,

--- a/assets/js/apps/search/components/filters/text-filter/TextFilter.jsx
+++ b/assets/js/apps/search/components/filters/text-filter/TextFilter.jsx
@@ -5,6 +5,27 @@ import FormControl from 'react-bootstrap/FormControl';
 import Button from 'react-bootstrap/Button';
 import PropTypes from 'prop-types';
 
+const _getValueContent = (value) => {
+    let valueContent = "";
+    if (value) {
+        if (value.op == "is") {
+            // If this is an exact match filter,
+            // the value would be the first array element of content. 
+            // This is because an "IS" operator filter
+            // uses filters for values.
+            return value.content[0];
+        } else if (value.op == "contains") {
+            // If this is a fuzzy match filter,
+            // the value would just be the content string.
+            return value.content;
+        } else {
+            return "";
+        }
+    } else {
+        return "";
+    }
+}
+
 const TextFilter = ({value,options,onValueChange}) => { 
     // Make a copy of the options first.
     options = Object.assign({},options);
@@ -14,10 +35,17 @@ const TextFilter = ({value,options,onValueChange}) => {
     if (!options.hint) {
         options.hint = "";
     }
-    const initialState = value ? value.content : "";
+    const initialState = _getValueContent(value);
     const [localValue, setLocalValue] = useState( initialState );
     useEffect(() => {
-        setLocalValue(value ? value.content : "");
+        // After the filter is initialised, the value may be
+        // updated externally - for example, we might restore an old value from
+        // query string in shareable URL.
+        // We update the local value when it is updated.
+        const newValue = _getValueContent(value);
+        if (newValue !== localValue){
+            setLocalValue(newValue);
+        }
     },[value])
     const handleValueChange = (e) => {
         setLocalValue(e.target.value);

--- a/assets/js/apps/search/components/filters/text-filter/TextFilter.jsx
+++ b/assets/js/apps/search/components/filters/text-filter/TextFilter.jsx
@@ -6,7 +6,6 @@ import Button from 'react-bootstrap/Button';
 import PropTypes from 'prop-types';
 
 const _getValueContent = (value) => {
-    let valueContent = "";
     if (value) {
         if (value.op === "is") {
             // If this is an exact match filter,

--- a/assets/js/apps/search/components/filters/text-filter/TextFilter.jsx
+++ b/assets/js/apps/search/components/filters/text-filter/TextFilter.jsx
@@ -8,13 +8,13 @@ import PropTypes from 'prop-types';
 const _getValueContent = (value) => {
     let valueContent = "";
     if (value) {
-        if (value.op == "is") {
+        if (value.op === "is") {
             // If this is an exact match filter,
             // the value would be the first array element of content. 
             // This is because an "IS" operator filter
             // uses filters for values.
             return value.content[0];
-        } else if (value.op == "contains") {
+        } else if (value.op === "contains") {
             // If this is a fuzzy match filter,
             // the value would just be the content string.
             return value.content;


### PR DESCRIPTION
When a text filter is configured with `{ isExact: true }`, if the filter's Filter button is pressed twice, the filter value will be wrapped in multiple arrays. This makes the query invalid and the search fails.
This PR fixes this problem.