### PR TITLE
Toggle sensitive parameter fields values in preview card.

### DIFF
--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.css
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.css
@@ -72,9 +72,14 @@
 .switch__label {
     display: flex;
     flex-flow: row wrap;
-    justify-content: space-between;
+    /* justify-content: space-between; */
+    justify-content: flex-start;
     align-items: center;
     /* background-color: pink; */
     width: 100%;
     padding: 1rem 0 0 0;
+}
+
+.sensitive__label-text {
+    margin-right: 0.5rem;
 }

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.css
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.css
@@ -72,10 +72,8 @@
 .switch__label {
     display: flex;
     flex-flow: row wrap;
-    /* justify-content: space-between; */
     justify-content: flex-start;
     align-items: center;
-    /* background-color: pink; */
     width: 100%;
     padding: 1rem 0 0 0;
 }

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.css
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.css
@@ -42,7 +42,7 @@
 }
 
 .preview-card__parameter-table {
-    margin: 2rem 0rem;
+    margin: 0.5rem 0rem;
 }
 
 .preview-card__header {
@@ -67,4 +67,14 @@
     display: flex;
     align-items: center;
     margin: 0 0.2em;
+}
+
+.switch__label {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-between;
+    align-items: center;
+    /* background-color: pink; */
+    width: 100%;
+    padding: 1rem 0 0 0;
 }

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
@@ -268,7 +268,20 @@ export default function EntryPreviewCard(props) {
             }
             <label htmlFor="showSensitiveDataSwitch" aria-label="Toggle sensitive data label" className="switch__label">
                 <span><b>Show sensitive values</b></span>
-                <Switch id="showSensitiveDataSwitch" aria-label="Toggle sensitive data switch" onChange={toggleSensitiveData} checked={showSensitiveData} />
+                <Switch 
+                    id="showSensitiveDataSwitch" 
+                    aria-label="Toggle sensitive data switch" 
+                    onChange={toggleSensitiveData} 
+                    checked={showSensitiveData} 
+                    checkedIcon={false}
+                    uncheckedIcon={false}
+                    height={20}
+                    width={40}
+                    handleDiameter={25}
+                    onHandleColor={'#007bff'}
+                    onColor={'#a3cfff'}
+                    boxShadow={'0 0 1px 1px #8a8a8a'}
+                />
             </label>
             <ParameterTable parameters={data.parameters} />
             <div className="preview-card__button-wrapper--right">

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
@@ -266,9 +266,9 @@ export default function EntryPreviewCard(props) {
                     Added on the {getDateAdded(data, type)}
                 </div>
             }
-            <label htmlFor="showSensitiveData" aria-label="Toggle sensitive data label" className="switch__label">
+            <label htmlFor="showSensitiveDataSwitch" aria-label="Toggle sensitive data label" className="switch__label">
                 <span><b>Show sensitive values</b></span>
-                <Switch id="showSensitiveData" aria-label="Toggle sensitive data switch" onChange={toggleSensitiveData} checked={showSensitiveData} />
+                <Switch id="showSensitiveDataSwitch" aria-label="Toggle sensitive data switch" onChange={toggleSensitiveData} checked={showSensitiveData} />
             </label>
             <ParameterTable parameters={data.parameters} />
             <div className="preview-card__button-wrapper--right">

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
@@ -4,6 +4,7 @@ import { updateHideSensitiveData, updateSelectedResult } from "../searchSlice";
 import './EntryPreviewCard.css'
 import moment from 'moment';
 import { FiUnlock, FiLock, FiX, FiPieChart } from 'react-icons/fi';
+import { Switch } from "react-switch";
 import {
     ProjectTabSticker,
     ExperimentTabSticker,
@@ -87,19 +88,19 @@ export default function EntryPreviewCard(props) {
      */
     const previewParameterTable = (parameters) => {
         return parameters.map((param, idx) => {
-            if (param.hasOwnProperty("sensitive")) {
-                if (hideSensitiveData) {
+            if (param.hasOwnProperty("sensitive") || true) {
+                if (!hideSensitiveData) {
                     return (
                         <tr key={`preview-card__param-entry-${idx}`} className="parameter-table__row">
-                            <td style={{ backgroundColor: '#fcfba2' }}><i class="fa fa-unlock-alt o-6"></i>{" " + param.pn_name}</td>
+                            <td style={{ backgroundColor: '#fcfba2' }}>{" " + param.pn_name}</td>
                             <td style={{ backgroundColor: '#fcfba2' }}><i class="fa fa-unlock-alt o-6"></i>{" " + param.value}</td>
                         </tr>
                     )
                 } else {
                     return (
                         <tr key={`preview-card__param-entry-${idx}`} className="parameter-table__row">
-                            <td style={{ backgroundColor: '#fcfba2' }}><FiLock aria-label="Sensitive parameter name"></FiLock>{" " + param.pn_name}</td>
-                            <td style={{ backgroundColor: '#fcfba2' }}><FiLock aria-label="Sensitive parameter value"></FiLock><i> Hidden. Click to show.</i></td>
+                            <td >{" " + param.pn_name}</td>
+                            <td ><FiLock aria-label="Sensitive parameter value"></FiLock><i> Hidden. Click to show.</i></td>
                         </tr>
                     )
                 }
@@ -271,6 +272,7 @@ export default function EntryPreviewCard(props) {
                 </div>
             }
             <Button onClick={toggleSensitiveData}>Show sensitive fields</Button>
+            <Switch onChange={toggleSensitiveData} checked={hideSensitiveData}></Switch>
             <ParameterTable parameters={data.parameters} />
             <div className="preview-card__button-wrapper--right">
                 <div className="preview-card__inline-block-wrapper">

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
@@ -24,9 +24,7 @@ export default function EntryPreviewCard(props) {
     let hideSensitiveData = useSelector(state => state.search.hideSensitiveData);
     const dispatch = useDispatch(),
     toggleSensitiveData = () => {
-        console.log('from', hideSensitiveData);
         dispatch(updateHideSensitiveData());
-        console.log('to', hideSensitiveData);
     };
 
     /**
@@ -93,7 +91,8 @@ export default function EntryPreviewCard(props) {
                     return (
                         <tr key={`preview-card__param-entry-${idx}`} className="parameter-table__row">
                             <td style={{ backgroundColor: '#fcfba2' }}>{" " + param.pn_name}</td>
-                            <td style={{ backgroundColor: '#fcfba2' }}><i class="fa fa-unlock-alt o-6"></i>{" " + param.value}</td>
+                            {/* <td style={{ backgroundColor: '#fcfba2' }}><i class="fa fa-unlock-alt o-6"></i>{" " + param.value}</td> */}
+                            <td style={{ backgroundColor: '#fcfba2' }}><FiUnlock></FiUnlock>{" " + param.value}</td>
                         </tr>
                     )
                 } else {
@@ -272,7 +271,7 @@ export default function EntryPreviewCard(props) {
                 </div>
             }
             <Button onClick={toggleSensitiveData}>Show sensitive fields</Button>
-            <Switch onChange={toggleSensitiveData} checked={hideSensitiveData}></Switch>
+            {/* <Switch onChange={toggleSensitiveData} checked={hideSensitiveData}></Switch> */}
             <ParameterTable parameters={data.parameters} />
             <div className="preview-card__button-wrapper--right">
                 <div className="preview-card__inline-block-wrapper">

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
@@ -1,6 +1,6 @@
 import { Button, Table } from 'react-bootstrap';
 import React, { useState } from 'react';
-import { updateHideSensitiveData, updateSelectedResult } from "../searchSlice";
+import { toggleShowSensitiveData, updateSelectedResult } from "../searchSlice";
 import './EntryPreviewCard.css'
 import moment from 'moment';
 import { FiUnlock, FiLock, FiX, FiPieChart } from 'react-icons/fi';
@@ -21,10 +21,10 @@ export default function EntryPreviewCard(props) {
     }
 
     // setting up redux logic
-    let hideSensitiveData = useSelector(state => state.search.hideSensitiveData);
+    let showSensitiveData = useSelector(state => state.search.showSensitiveData);
     const dispatch = useDispatch(),
     toggleSensitiveData = () => {
-        dispatch(updateHideSensitiveData());
+        dispatch(toggleShowSensitiveData());
     };
 
     /**
@@ -87,7 +87,7 @@ export default function EntryPreviewCard(props) {
     const previewParameterTable = (parameters) => {
         return parameters.map((param, idx) => {
             if (param.hasOwnProperty("sensitive")) {
-                if (!hideSensitiveData) {
+                if (showSensitiveData) {
                     return (
                         <tr key={`preview-card__param-entry-${idx}`} className="parameter-table__row">
                             <td style={{ backgroundColor: '#fcfba2' }}>{" " + param.pn_name}</td>
@@ -270,9 +270,9 @@ export default function EntryPreviewCard(props) {
                 </div>
             }
             {/* <Button onClick={toggleSensitiveData}>Show sensitive fields</Button> */}
-            <label htmlFor="hideSensitiveSwitch" aria-label="Toggle sensitive data label" className="switch__label">
-                <span>Show hidden fields</span>
-                <Switch id="hideSensitiveSwitch" aria-label="Toggle sensitive data switch" onChange={toggleSensitiveData} checked={hideSensitiveData} />
+            <label htmlFor="showSensitiveData" aria-label="Toggle sensitive data label" className="switch__label">
+                <span>Show senstive values</span>
+                <Switch id="showSensitiveData" aria-label="Toggle sensitive data switch" onChange={toggleSensitiveData} checked={showSensitiveData} />
             </label>
             <ParameterTable parameters={data.parameters} />
             <div className="preview-card__button-wrapper--right">

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
@@ -49,7 +49,7 @@ export default function EntryPreviewCard(props) {
             case 'experiment':
                 return data.title;
             case 'dataset':
-                return `${data.description} #${data.id}`
+                return data.description
             case 'datafile':
                 return data.filename;
         }
@@ -247,9 +247,6 @@ export default function EntryPreviewCard(props) {
     return (
         <div className="preview-card__body">
             <span className="preview-card__close" aria-label="Close preview panel">
-                {/* <button onClick={onClick}>
-                    <FiX />
-                </button> */}
             </span>
             <div className="preview-card__header">
                 <div >
@@ -269,9 +266,8 @@ export default function EntryPreviewCard(props) {
                     Added on the {getDateAdded(data, type)}
                 </div>
             }
-            {/* <Button onClick={toggleSensitiveData}>Show sensitive fields</Button> */}
             <label htmlFor="showSensitiveData" aria-label="Toggle sensitive data label" className="switch__label">
-                <span>Show senstive values</span>
+                <span><b>Show sensitive values</b></span>
                 <Switch id="showSensitiveData" aria-label="Toggle sensitive data switch" onChange={toggleSensitiveData} checked={showSensitiveData} />
             </label>
             <ParameterTable parameters={data.parameters} />

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
@@ -4,7 +4,7 @@ import { updateHideSensitiveData, updateSelectedResult } from "../searchSlice";
 import './EntryPreviewCard.css'
 import moment from 'moment';
 import { FiUnlock, FiLock, FiX, FiPieChart } from 'react-icons/fi';
-import { Switch } from "react-switch";
+import Switch from "react-switch";
 import {
     ProjectTabSticker,
     ExperimentTabSticker,
@@ -86,12 +86,11 @@ export default function EntryPreviewCard(props) {
      */
     const previewParameterTable = (parameters) => {
         return parameters.map((param, idx) => {
-            if (param.hasOwnProperty("sensitive") || true) {
+            if (param.hasOwnProperty("sensitive")) {
                 if (!hideSensitiveData) {
                     return (
                         <tr key={`preview-card__param-entry-${idx}`} className="parameter-table__row">
                             <td style={{ backgroundColor: '#fcfba2' }}>{" " + param.pn_name}</td>
-                            {/* <td style={{ backgroundColor: '#fcfba2' }}><i class="fa fa-unlock-alt o-6"></i>{" " + param.value}</td> */}
                             <td style={{ backgroundColor: '#fcfba2' }}><FiUnlock></FiUnlock>{" " + param.value}</td>
                         </tr>
                     )
@@ -99,7 +98,7 @@ export default function EntryPreviewCard(props) {
                     return (
                         <tr key={`preview-card__param-entry-${idx}`} className="parameter-table__row">
                             <td >{" " + param.pn_name}</td>
-                            <td ><FiLock aria-label="Sensitive parameter value"></FiLock><i> Hidden. Click to show.</i></td>
+                            <td ><FiLock aria-label="Sensitive parameter value"></FiLock><i> Hidden. Toggle to show.</i></td>
                         </tr>
                     )
                 }
@@ -270,8 +269,11 @@ export default function EntryPreviewCard(props) {
                     Added on the {getDateAdded(data, type)}
                 </div>
             }
-            <Button onClick={toggleSensitiveData}>Show sensitive fields</Button>
-            {/* <Switch onChange={toggleSensitiveData} checked={hideSensitiveData}></Switch> */}
+            {/* <Button onClick={toggleSensitiveData}>Show sensitive fields</Button> */}
+            <label aria-label="Toggle sensitive data label" className="switch__label">
+                <span>Show hidden fields</span>
+                <Switch aria-label="Toggle sensitive data switch" onChange={toggleSensitiveData} checked={hideSensitiveData} />
+            </label>
             <ParameterTable parameters={data.parameters} />
             <div className="preview-card__button-wrapper--right">
                 <div className="preview-card__inline-block-wrapper">

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
@@ -1,6 +1,6 @@
 import { Button, Table } from 'react-bootstrap';
 import React, { useState } from 'react';
-import { updateHideSensitiveData } from "../searchSlice";
+import { updateHideSensitiveData, updateSelectedResult } from "../searchSlice";
 import './EntryPreviewCard.css'
 import moment from 'moment';
 import { FiUnlock, FiLock, FiX, FiPieChart } from 'react-icons/fi';
@@ -10,14 +10,23 @@ import {
     DatasetTabSticker,
     DatafileTabSticker
 } from '../TabStickers/TabSticker';
-// import { useSelector, useDispatch } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 
 export default function EntryPreviewCard(props) {
-    let { data, onToggleSensitiveData, hideSensitiveData } = props;
+    let { data } = props;
     let type;
     if (data) {
         type = data.type;
     }
+
+    // setting up redux logic
+    let hideSensitiveData = useSelector(state => state.search.hideSensitiveData);
+    const dispatch = useDispatch(),
+    toggleSensitiveData = () => {
+        console.log('from', hideSensitiveData);
+        dispatch(updateHideSensitiveData());
+        console.log('to', hideSensitiveData);
+    };
 
     /**
      * Simply cuts of the time portion of the date
@@ -70,6 +79,7 @@ export default function EntryPreviewCard(props) {
         }
         return (!!date ? formatDate(date) : null);
     }
+
 
     /**
      * Returns an table of parameters.
@@ -226,13 +236,6 @@ export default function EntryPreviewCard(props) {
         }
     }
 
-    /**
-     * Changes the hide sensitive data state to the opposite it's current state.    
-     */
-    const toggleHideSensitiveState = () => {
-        alert('hide sens data');
-    }
-
     if (data === null) {
         return (
             <div className="preview-card__body">
@@ -240,6 +243,8 @@ export default function EntryPreviewCard(props) {
             </div>
         )
     }
+
+
     return (
         <div className="preview-card__body">
             <span className="preview-card__close" aria-label="Close preview panel">
@@ -265,7 +270,7 @@ export default function EntryPreviewCard(props) {
                     Added on the {getDateAdded(data, type)}
                 </div>
             }
-            <Button onClick={onToggleSensitiveData}>Show sensitive fields</Button>
+            <Button onClick={toggleSensitiveData}>Show sensitive fields</Button>
             <ParameterTable parameters={data.parameters} />
             <div className="preview-card__button-wrapper--right">
                 <div className="preview-card__inline-block-wrapper">

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
@@ -270,9 +270,9 @@ export default function EntryPreviewCard(props) {
                 </div>
             }
             {/* <Button onClick={toggleSensitiveData}>Show sensitive fields</Button> */}
-            <label aria-label="Toggle sensitive data label" className="switch__label">
+            <label htmlFor="hideSensitiveSwitch" aria-label="Toggle sensitive data label" className="switch__label">
                 <span>Show hidden fields</span>
-                <Switch aria-label="Toggle sensitive data switch" onChange={toggleSensitiveData} checked={hideSensitiveData} />
+                <Switch id="hideSensitiveSwitch" aria-label="Toggle sensitive data switch" onChange={toggleSensitiveData} checked={hideSensitiveData} />
             </label>
             <ParameterTable parameters={data.parameters} />
             <div className="preview-card__button-wrapper--right">

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
@@ -23,9 +23,9 @@ export default function EntryPreviewCard(props) {
     // setting up redux logic
     let showSensitiveData = useSelector(state => state.search.showSensitiveData);
     const dispatch = useDispatch(),
-    toggleSensitiveData = () => {
-        dispatch(toggleShowSensitiveData());
-    };
+        toggleSensitiveData = () => {
+            dispatch(toggleShowSensitiveData());
+        };
 
     /**
      * Simply cuts of the time portion of the date
@@ -266,23 +266,25 @@ export default function EntryPreviewCard(props) {
                     Added on the {getDateAdded(data, type)}
                 </div>
             }
-            <label htmlFor="showSensitiveDataSwitch" aria-label="Toggle sensitive data label" className="switch__label">
-                <span><b>Show sensitive values</b></span>
-                <Switch 
-                    id="showSensitiveDataSwitch" 
-                    aria-label="Toggle sensitive data switch" 
-                    onChange={toggleSensitiveData} 
-                    checked={showSensitiveData} 
-                    checkedIcon={false}
-                    uncheckedIcon={false}
-                    height={20}
-                    width={40}
-                    handleDiameter={25}
-                    onHandleColor={'#007bff'}
-                    onColor={'#a3cfff'}
-                    boxShadow={'0 0 1px 1px #8a8a8a'}
-                />
-            </label>
+            { data.parameters.length < 1 ? null :
+                <label htmlFor="showSensitiveDataSwitch" aria-label="Toggle sensitive data label" className="switch__label">
+                    <span><b>Show sensitive values</b></span>
+                    <Switch
+                        id="showSensitiveDataSwitch"
+                        aria-label="Toggle sensitive data switch"
+                        onChange={toggleSensitiveData}
+                        checked={showSensitiveData}
+                        checkedIcon={false}
+                        uncheckedIcon={false}
+                        height={20}
+                        width={40}
+                        handleDiameter={25}
+                        onHandleColor={'#007bff'}
+                        onColor={'#a3cfff'}
+                        boxShadow={'0 0 1px 1px #8a8a8a'}
+                    />
+                </label>
+            }
             <ParameterTable parameters={data.parameters} />
             <div className="preview-card__button-wrapper--right">
                 <div className="preview-card__inline-block-wrapper">

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
@@ -268,7 +268,7 @@ export default function EntryPreviewCard(props) {
             }
             { data.parameters.length < 1 ? null :
                 <label htmlFor="showSensitiveDataSwitch" aria-label="Toggle sensitive data label" className="switch__label">
-                    <span><b>Show sensitive values</b></span>
+                    <span className="sensitive__label-text"><b>Show sensitive values</b></span>
                     <Switch
                         id="showSensitiveDataSwitch"
                         aria-label="Toggle sensitive data switch"

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.jsx
@@ -1,5 +1,6 @@
 import { Button, Table } from 'react-bootstrap';
 import React, { useState } from 'react';
+import { updateHideSensitiveData } from "../searchSlice";
 import './EntryPreviewCard.css'
 import moment from 'moment';
 import { FiUnlock, FiLock, FiX, FiPieChart } from 'react-icons/fi';
@@ -9,9 +10,10 @@ import {
     DatasetTabSticker,
     DatafileTabSticker
 } from '../TabStickers/TabSticker';
+// import { useSelector, useDispatch } from "react-redux";
 
 export default function EntryPreviewCard(props) {
-    let { data, onClick } = props;
+    let { data, onToggleSensitiveData, hideSensitiveData } = props;
     let type;
     if (data) {
         type = data.type;
@@ -74,10 +76,9 @@ export default function EntryPreviewCard(props) {
      * @param {Object} parameters The parameter section of the response data.
      */
     const previewParameterTable = (parameters) => {
-        let hideSensitive = false;
         return parameters.map((param, idx) => {
             if (param.hasOwnProperty("sensitive")) {
-                if (hideSensitive) {
+                if (hideSensitiveData) {
                     return (
                         <tr key={`preview-card__param-entry-${idx}`} className="parameter-table__row">
                             <td style={{ backgroundColor: '#fcfba2' }}><i class="fa fa-unlock-alt o-6"></i>{" " + param.pn_name}</td>
@@ -264,7 +265,7 @@ export default function EntryPreviewCard(props) {
                     Added on the {getDateAdded(data, type)}
                 </div>
             }
-            <Button onClick={toggleHideSensitiveState}>Show sensitive fields</Button>
+            <Button onClick={onToggleSensitiveData}>Show sensitive fields</Button>
             <ParameterTable parameters={data.parameters} />
             <div className="preview-card__button-wrapper--right">
                 <div className="preview-card__inline-block-wrapper">

--- a/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.stories.jsx
+++ b/assets/js/apps/search/components/PreviewCard/EntryPreviewCard.stories.jsx
@@ -1,13 +1,25 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions';
 import EntryPreviewCard from './EntryPreviewCard';
+import makeMockStore from "../../util/makeMockStore";
+import { Provider } from 'react-redux';
+
+const store = makeMockStore({
+  search: {
+    hideSensitiveData: false
+  }
+});
 
 export default {
   component: EntryPreviewCard,
   title: 'EntryPreviewCard',
-  decorators: [story => <div style={{ 
-    border: '2px solid black'
-  }}>{story()}</div>],
+  decorators: [story =>
+    <Provider store={store}>
+      <div style={{
+        border: '2px solid black'
+      }}>{story()}</div>
+    </Provider>
+  ],
 };
 
 const project = {
@@ -102,76 +114,76 @@ const experiment = {
 
 const dataSet = {
   "url": "idk/",
-  "counts":{
-     "datafiles":2
+  "counts": {
+    "datafiles": 2
   },
-  "created_time":"2020-05-07T23:00:05+00:00",
-  "description":"Some ACL-testing dataset",
-  "experiments":[
-     {
-        "id":4,
-        "project":{
-           "id":1
-        }
-     }
+  "created_time": "2020-05-07T23:00:05+00:00",
+  "description": "Some ACL-testing dataset",
+  "experiments": [
+    {
+      "id": 4,
+      "project": {
+        "id": 1
+      }
+    }
   ],
-  "id":1,
-  "instrument":{
-     "id":1,
-     "name":"Mikes_ACL_Machine"
+  "id": 1,
+  "instrument": {
+    "id": 1,
+    "name": "Mikes_ACL_Machine"
   },
-  "modified_time":"2020-06-09T02:10:18.426980+00:00",
-  "parameters":[
-     {
-        "data_type":"STRING",
-        "pn_name":"4",
-        "sensitive":"False",
-        "value":"My Name"
-     },
-     {
-        "data_type":"STRING",
-        "pn_name":"5",
-        "sensitive":"False",
-        "value":"is"
-     }
+  "modified_time": "2020-06-09T02:10:18.426980+00:00",
+  "parameters": [
+    {
+      "data_type": "STRING",
+      "pn_name": "4",
+      "sensitive": "False",
+      "value": "My Name"
+    },
+    {
+      "data_type": "STRING",
+      "pn_name": "5",
+      "sensitive": "False",
+      "value": "is"
+    }
   ],
-  "size":"460.3 KB",
-  "tags":"bricks safe as",
+  "size": "460.3 KB",
+  "tags": "bricks safe as",
   "type": "dataset",
-  "userDownloadRights":"partial"
+  "userDownloadRights": "partial"
 }
 
 const dataFile = {
   "url": "idk/",
   "type": "datafile",
-  "created_time":null,
-  "dataset":{
-     "experiments":[
-        {
-           "id":4,
-           "project":{
-              "id":1
-           }
+  "created_time": null,
+  "dataset": {
+    "experiments": [
+      {
+        "id": 4,
+        "project": {
+          "id": 1
         }
-     ],
-     "id":1
+      }
+    ],
+    "id": 1
   },
-  "filename":"Mikes_test_datafile_1",
-  "id":1,
-  "modification_time":null,
-  "parameters":[
-     {
-        "data_type":"STRING",
-        "pn_name":"12",
-        "sensitive":"False",
-        "value":"My name is"
-     }
+  "filename": "Mikes_test_datafile_1",
+  "id": 1,
+  "modification_time": null,
+  "parameters": [
+    {
+      "data_type": "STRING",
+      "pn_name": "12",
+      "sensitive": "False",
+      "value": "My name is"
+    }
   ],
-  "size":"460.3 KB",
-  "userDownloadRights":"full"
+  "size": "460.3 KB",
+  "userDownloadRights": "full"
 }
 
-const projectWithNoChildren = Object.assign({},project,{
+const projectWithNoChildren = Object.assign({}, project, {
   counts: {
     experiments: 0,
     datasets: 0,

--- a/assets/js/apps/search/components/ResultSection.jsx
+++ b/assets/js/apps/search/components/ResultSection.jsx
@@ -7,7 +7,7 @@ import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Nav from 'react-bootstrap/Nav';
 import Badge from 'react-bootstrap/Badge';
 import { useSelector, useDispatch } from "react-redux";
-import { updateSelectedResult, updateSelectedType,updateHideSensitiveData } from "./searchSlice";
+import { updateSelectedResult, updateSelectedType } from "./searchSlice";
 import './ResultSection.css';
 import EntryPreviewCard from './PreviewCard/EntryPreviewCard';
 
@@ -200,7 +200,7 @@ PureResultList.propTypes = {
 }
 
 export function PureResultSection({ resultSets, selectedType,
-    onSelectType, selectedResult, onSelectResult, isLoading, error, hideSensitiveData, onToggleSensitiveData }) {
+    onSelectType, selectedResult, onSelectResult, isLoading, error }) {
     let counts;
     if (!resultSets) {
         resultSets = {};
@@ -235,8 +235,6 @@ export function PureResultSection({ resultSets, selectedType,
                     {(!isLoading && !error && currentCount > 0) &&
                         <EntryPreviewCard
                             data={selectedEntry}
-                            hideSensitiveData={hideSensitiveData}
-                            onToggleSensitiveData={onToggleSensitiveData}
                         />
                     }
                 </div>
@@ -274,11 +272,6 @@ export default function ResultSection() {
             (state) => state.search
         );
 
-    const hideSensitiveData = useSelector(state => state.search.hideSensitiveData),
-        onToggleSensitiveData = () => {
-            dispatch(updateHideSensitiveData(hideSensitiveData))
-        };
-
     return (
         <PureResultSection
             resultSets={searchInfo.results}
@@ -288,8 +281,6 @@ export default function ResultSection() {
             onSelectType={onSelectType}
             selectedResult={selectedResult}
             onSelectResult={onSelectResult}
-            hideSensitiveData={hideSensitiveData}
-            onToggleSensitiveData={onToggleSensitiveData}
         />
     )
 }

--- a/assets/js/apps/search/components/ResultSection.jsx
+++ b/assets/js/apps/search/components/ResultSection.jsx
@@ -7,7 +7,7 @@ import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Nav from 'react-bootstrap/Nav';
 import Badge from 'react-bootstrap/Badge';
 import { useSelector, useDispatch } from "react-redux";
-import { updateSelectedResult, updateSelectedType } from "./searchSlice";
+import { updateSelectedResult, updateSelectedType,updateHideSensitiveData } from "./searchSlice";
 import './ResultSection.css';
 import EntryPreviewCard from './PreviewCard/EntryPreviewCard';
 
@@ -200,7 +200,7 @@ PureResultList.propTypes = {
 }
 
 export function PureResultSection({ resultSets, selectedType,
-    onSelectType, selectedResult, onSelectResult, isLoading, error }) {
+    onSelectType, selectedResult, onSelectResult, isLoading, error, hideSensitiveData, onToggleSensitiveData }) {
     let counts;
     if (!resultSets) {
         resultSets = {};
@@ -235,6 +235,8 @@ export function PureResultSection({ resultSets, selectedType,
                     {(!isLoading && !error && currentCount > 0) &&
                         <EntryPreviewCard
                             data={selectedEntry}
+                            hideSensitiveData={hideSensitiveData}
+                            onToggleSensitiveData={onToggleSensitiveData}
                         />
                     }
                 </div>
@@ -271,6 +273,12 @@ export default function ResultSection() {
         searchInfo = useSelector(
             (state) => state.search
         );
+
+    const hideSensitiveData = useSelector(state => state.search.hideSensitiveData),
+        onToggleSensitiveData = () => {
+            dispatch(updateHideSensitiveData(hideSensitiveData))
+        };
+
     return (
         <PureResultSection
             resultSets={searchInfo.results}
@@ -280,6 +288,8 @@ export default function ResultSection() {
             onSelectType={onSelectType}
             selectedResult={selectedResult}
             onSelectResult={onSelectResult}
+            hideSensitiveData={hideSensitiveData}
+            onToggleSensitiveData={onToggleSensitiveData}
         />
     )
 }

--- a/assets/js/apps/search/components/searchSlice.jsx
+++ b/assets/js/apps/search/components/searchSlice.jsx
@@ -82,7 +82,8 @@ const search = createSlice({
             state.selectedResult = selectedResult;
         },
         updateHideSensitiveData: (state) => {
-            state.hideSensitiveData = !state.hideSensitiveData;
+            // state.hideSensitiveData = !state.hideSensitiveData;
+            state.hideSensitiveData = true;
         }
     }
 })

--- a/assets/js/apps/search/components/searchSlice.jsx
+++ b/assets/js/apps/search/components/searchSlice.jsx
@@ -82,8 +82,7 @@ const search = createSlice({
             state.selectedResult = selectedResult;
         },
         updateHideSensitiveData: (state) => {
-            // state.hideSensitiveData = !state.hideSensitiveData;
-            state.hideSensitiveData = true;
+            state.hideSensitiveData = !state.hideSensitiveData;
         }
     }
 })

--- a/assets/js/apps/search/components/searchSlice.jsx
+++ b/assets/js/apps/search/components/searchSlice.jsx
@@ -41,7 +41,7 @@ const initialState = {
     activeFilters: [],
     selectedType: "experiment",
     selectedResult: null,
-    hideSensitive: true
+    hideSensitiveData: true
 };
 
 const search = createSlice({
@@ -80,6 +80,9 @@ const search = createSlice({
         },
         updateSelectedResult: (state, {payload: selectedResult}) => {
             state.selectedResult = selectedResult;
+        },
+        updateHideSensitiveData: (state) => {
+            state.hideSensitiveData = !state.hideSensitiveData;
         }
     }
 })
@@ -210,7 +213,8 @@ export const {
     getResultsFailure,
     updateSearchTerm,
     updateSelectedType,
-    updateSelectedResult
+    updateSelectedResult,
+    updateHideSensitiveData
 } = search.actions;
 
 export default search.reducer;

--- a/assets/js/apps/search/components/searchSlice.jsx
+++ b/assets/js/apps/search/components/searchSlice.jsx
@@ -41,7 +41,7 @@ const initialState = {
     activeFilters: [],
     selectedType: "experiment",
     selectedResult: null,
-    hideSensitiveData: true
+    showSensitiveData: false
 };
 
 const search = createSlice({
@@ -81,8 +81,8 @@ const search = createSlice({
         updateSelectedResult: (state, {payload: selectedResult}) => {
             state.selectedResult = selectedResult;
         },
-        updateHideSensitiveData: (state) => {
-            state.hideSensitiveData = !state.hideSensitiveData;
+        toggleShowSensitiveData: (state) => {
+            state.showSensitiveData = !state.showSensitiveData;
         }
     }
 })
@@ -214,7 +214,7 @@ export const {
     updateSearchTerm,
     updateSelectedType,
     updateSelectedResult,
-    updateHideSensitiveData
+    toggleShowSensitiveData
 } = search.actions;
 
 export default search.reducer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22642,6 +22642,14 @@
         "throttle-debounce": "^2.1.0"
       }
     },
+    "react-switch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-5.0.1.tgz",
+      "integrity": "sha512-Pa5kvqRfX85QUCK1Jv0rxyeElbC3aNpCP5hV0LoJpU/Y6kydf0t4kRriQ6ZYA4kxWwAYk/cH51T4/sPzV9mCgQ==",
+      "requires": {
+        "prop-types": "^15.6.2"
+      }
+    },
     "react-syntax-highlighter": {
       "version": "12.2.1",
       "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-dom": "^16.10.2",
     "react-icons": "^3.10.0",
     "react-redux": "^7.2.0",
+    "react-switch": "^5.0.1",
     "react-tag-autocomplete": "^5.8.0",
     "react-treebeard": "^3.2.4",
     "select2": "^4.0.12",

--- a/tardis/tardis_portal/views/pages.py
+++ b/tardis/tardis_portal/views/pages.py
@@ -134,7 +134,7 @@ class IndexView(TemplateView):
         c = super().get_context_data(**kwargs)
         status = ''
         limit = 8
-        project_limit = 5
+        project_limit = 4
         c['status'] = status
         if request.user.is_authenticated:
             private_experiments = Experiment.safe.owned_and_shared(

--- a/tardis/tardis_portal/views/pages.py
+++ b/tardis/tardis_portal/views/pages.py
@@ -134,6 +134,7 @@ class IndexView(TemplateView):
         c = super().get_context_data(**kwargs)
         status = ''
         limit = 8
+        project_limit = 5
         c['status'] = status
         if request.user.is_authenticated:
             private_experiments = Experiment.safe.owned_and_shared(
@@ -149,7 +150,7 @@ class IndexView(TemplateView):
         c['exps_expand_accordion'] = 1
 
         private_projects = Project.safe.owned_and_shared(
-                    request.user).order_by('-start_date')
+                    request.user).order_by('-start_date')[:project_limit]
         c['private_projects'] = private_projects
         c['private_projects_count'] = private_projects.count()
         return c


### PR DESCRIPTION
__No need to review currently__ 

* Added a toggle switch to allow toggling between hiding values for specified parameter fields on a preview card.
* Limited homepage "most recent projects" list to 4 (the same limit as experiment listings).
* Added redux state for hiding sensitive parameter values. Toggle state persists throughout the search page.
* Adjusted dataset header on preview cards to exclude their dataset id. 