### PR TITLE
Fix parsing for numbers and special characters

### DIFF
--- a/assets/js/apps/search/components/searchSlice.spec.jsx
+++ b/assets/js/apps/search/components/searchSlice.spec.jsx
@@ -1,0 +1,19 @@
+import { parseQuery } from "./searchSlice";
+
+describe("Query parser", () => {
+    it("can parse text search terms", () => {
+        expect(parseQuery("?q=abc")).toEqual({query: "abc"});
+    });
+
+    it("can parse numerical search terms", () => {
+        expect(parseQuery("?q=2")).toEqual({query: "2"});
+    });
+
+    it("can parse complex search query", () => {
+        expect(parseQuery("?q={\"filters\":\"1\"}")).toEqual({filters: "1"});
+    });
+
+    it("can parse special characters", () => {
+        expect(parseQuery("?q=%3A")).toEqual({query: ":"});
+    })
+});


### PR DESCRIPTION
This branch fixes bugs with the search page parsing the URL for search filters. An error would occur when a user types a number or special character into the search box at the top of the page. This is caused by the parser assuming any valid JSON would mean it's a filter object.