### PR TITLE
Make Tardis URLs consistent + remove /app/

### DIFF
--- a/assets/js/apps/project_detail_view/index.jsx
+++ b/assets/js/apps/project_detail_view/index.jsx
@@ -10,7 +10,7 @@ let mountPoint = document.getElementById('project-app');
 const { href } = window.location;
 // console.log(href);
 
-const projectId = href.substring(href.lastIndexOf("/") + 1);
+const projectId = href.substring(href.lastIndexOf("/", href.lastIndexOf("/") - 1 ) + 1, href.lastIndexOf("/"));
 
 ReactDOM.render(
   <div>

--- a/assets/js/apps/search/components/searchSlice.jsx
+++ b/assets/js/apps/search/components/searchSlice.jsx
@@ -27,7 +27,7 @@ const hits = response.hits,
     }
     if (hits.datasets) {
         results.datasets = hits.datasets.map((hit) => {
-            return getResultFromHit(hit,"dataset","/dataset")
+            return getResultFromHit(hit,"dataset","/dataset/view")
         });
     }
     if (hits.datafiles) {
@@ -126,11 +126,11 @@ export const totalPagesSelector = (searchSlice, typeId) => (
 export const searchTermSelector = (searchSlice, typeId) => (
     // Check search term exists and is an object before returning
     // search term.
-    (searchSlice && 
+    (searchSlice &&
         searchSlice.searchTerm &&
-        typeof searchSlice.searchTerm === "object" && 
+        typeof searchSlice.searchTerm === "object" &&
         !Array.isArray(searchSlice.searchTerm))
-        ? 
+        ?
         searchSlice.searchTerm[typeId] : ""
 );
 
@@ -221,7 +221,7 @@ const search = createSlice({
                 }
             });
             // Finally, if there are no search terms, delete
-            // the empty object. 
+            // the empty object.
             if (Object.keys(state.searchTerm).length === 0) {
                 state.searchTerm = undefined;
             }
@@ -315,7 +315,7 @@ const fetchSearchResults = (queryBody) => {
 
 
 /**
- * Returns search API pagination query. 
+ * Returns search API pagination query.
  * @param {*} searchSlice - Redux search slice
  * @param {string} type If null, returns pagination for all types. If a MyTardis
  * type is specified, returns only pagination for that type.
@@ -354,7 +354,7 @@ const buildSortQuery = (state, typeToSearch) => {
             return {
                 field: fullField,
                 order
-            };            
+            };
         });
         if (typeSortQuery.length !== 0) {
             acc[typeId] = typeSortQuery;
@@ -432,7 +432,7 @@ export const hasActiveSearchTermSelector = searchSlice => {
  */
 export const parseQuery = (searchString) => {
     const convertLegacySearchTermQuery = (searchTerm) => {
-        // Convert text string search term queries 
+        // Convert text string search term queries
         // to new format if so.
         if (!searchTerm) {
             return {};
@@ -462,7 +462,7 @@ export const parseQuery = (searchString) => {
         }
     };
 
-    
+
     // Find and return the query string or JSON body.
     if (searchString[0] === "?") {
         searchString = searchString.substring(1);
@@ -490,7 +490,7 @@ const updateWithQuery = (queryBody) => {
                 searchTerm: queryBody.query,
                 replaceState: true
             }));
-            dispatch(updateFiltersByQuery(queryBody.filters));    
+            dispatch(updateFiltersByQuery(queryBody.filters));
         });
     }
 }

--- a/assets/js/apps/tree_view/index.jsx
+++ b/assets/js/apps/tree_view/index.jsx
@@ -7,5 +7,6 @@ import TreeView from './components/TreeView';
 
 const content = document.getElementById('tree_view');
 const { href } = window.location;
-const datasetId = href.substring(href.lastIndexOf('/') + 1);
+
+const datasetId = href.substring(href.lastIndexOf("/", href.lastIndexOf("/") - 1 ) + 1, href.lastIndexOf("/"));
 ReactDOM.render(<TreeView datasetId={datasetId} />, content);

--- a/features/steps/search.py
+++ b/features/steps/search.py
@@ -6,7 +6,7 @@ def they_open_the_search_url(context):
     """
     :type context: behave.runner.Context
     """
-    context.browser.get(context.base_url + "/apps/search/")
+    context.browser.get(context.base_url + "/search/")
 
 
 @then("they see the search page")

--- a/tardis/tardis_portal/templates/tardis_portal/facility_overview.html
+++ b/tardis/tardis_portal/templates/tardis_portal/facility_overview.html
@@ -179,7 +179,7 @@
                         <td>{{dataset.owner}}</td>
                         <td>{{dataset.group}}</td>
                         <td><a href="/experiment/view/{{dataset.parent_experiment.id}}/" target="_blank">{{dataset.parent_experiment.title}}</a></td>
-                        <td><a href="/dataset/{{dataset.id}}" target="_blank">{{dataset.description}}</a></td>
+                        <td><a href="/dataset/view/{{dataset.id}}" target="_blank">{{dataset.description}}</a></td>
                         <td>{{dataset.instrument.name}}</td>
                         <td>{{dataset.created_time | date:'yyyy-MM-dd h:mma'}}</td>
                         <td>
@@ -223,7 +223,7 @@
                         <td>{{dataset.owner}}</td>
                         <td>{{dataset.group}}</td>
                         <td><a href="/experiment/view/{{dataset.parent_experiment.id}}/" target="_blank">{{dataset.parent_experiment.title}}</a></td>
-                        <td><a href="/dataset/{{dataset.id}}" target="_blank">{{dataset.description}}</a></td>
+                        <td><a href="/dataset/view/{{dataset.id}}" target="_blank">{{dataset.description}}</a></td>
                         <td>{{dataset.created_time | date:'yyyy-MM-dd h:mma'}}</td>
                         <td>
                           <span ng-include="'showHideFileListButton'"></span>
@@ -263,7 +263,7 @@
                       </tr>
                       <tr ng-repeat-start="dataset in datasetByUser.datasets | filter:facilityCtrl.search_experiment:strict | filter:facilityCtrl.search_instrument:strict">
                         <td><a href="/experiment/view/{{dataset.parent_experiment.id}}/" target="_blank">{{dataset.parent_experiment.title}}</a></td>
-                        <td><a href="/dataset/{{dataset.id}}" target="_blank">{{dataset.description}}</a></td>
+                        <td><a href="/dataset/view/{{dataset.id}}" target="_blank">{{dataset.description}}</a></td>
                         <td>{{dataset.instrument.name}}</td>
                         <td>{{dataset.created_time | date:'yyyy-MM-dd h:mma'}}</td>
                         <td>

--- a/tardis/tardis_portal/tests/models/test_dataset.py
+++ b/tardis/tardis_portal/tests/models/test_dataset.py
@@ -83,8 +83,8 @@ class DatasetTestCase(ModelTestCase):
         self.assertEqual(instrument, dataset.instrument)
         target_id = Dataset.objects.first().id
         self.assertEqual(
-            dataset.get_absolute_url(), '/dataset/%d' % target_id,
-            dataset.get_absolute_url() + ' != /dataset/%d' % target_id)
+            dataset.get_absolute_url(), '/dataset/view/%d' % target_id,
+            dataset.get_absolute_url() + ' != /dataset/view/%d' % target_id)
 
     def test_get_dir_tuples(self):
         dataset = Dataset.objects.create(description='test dataset1')

--- a/tardis/tardis_portal/tests/models/test_dataset.py
+++ b/tardis/tardis_portal/tests/models/test_dataset.py
@@ -83,8 +83,8 @@ class DatasetTestCase(ModelTestCase):
         self.assertEqual(instrument, dataset.instrument)
         target_id = Dataset.objects.first().id
         self.assertEqual(
-            dataset.get_absolute_url(), '/dataset/view/%d' % target_id,
-            dataset.get_absolute_url() + ' != /dataset/view/%d' % target_id)
+            dataset.get_absolute_url(), '/dataset/view/%d/' % target_id,
+            dataset.get_absolute_url() + ' != /dataset/view/%d/' % target_id)
 
     def test_get_dir_tuples(self):
         dataset = Dataset.objects.create(description='test dataset1')

--- a/tardis/tardis_portal/tests/test_parameters.py
+++ b/tardis/tardis_portal/tests/test_parameters.py
@@ -225,7 +225,7 @@ class ParametersTestCase(TestCase):
         dataset_link_param = DatasetParameter.objects.create(
             parameterset=dataset_parameterset,
             name=self.pnames[ParameterName.LINK])
-        dataset_url = self.dataset.get_absolute_url()  # /dataset/1/
+        dataset_url = self.dataset.get_absolute_url()  # /dataset/view/1/
         dataset_link_param.set_value(dataset_url)
         dataset_link_param.save()
         self.assertEqual(
@@ -240,7 +240,7 @@ class ParametersTestCase(TestCase):
         datafile_link_param = DatafileParameter.objects.create(
             parameterset=datafile_parameterset,
             name=self.pnames[ParameterName.LINK])
-        dataset_url = self.dataset.get_absolute_url()  # /dataset/1/
+        dataset_url = self.dataset.get_absolute_url()  # /dataset/view/1/
         datafile_link_param.set_value(dataset_url)
         datafile_link_param.save()
         self.assertEqual(

--- a/tardis/tardis_portal/tests/test_parametersets.py
+++ b/tardis/tardis_portal/tests/test_parametersets.py
@@ -196,7 +196,7 @@ class ParameterSetManagerTestCase(TestCase):
         self.dataset_link_param = DatafileParameter(
             parameterset=self.datafileparameterset,
             name=self.parametername_dataset_link)
-        dataset_url = self.dataset.get_absolute_url()  # /dataset/1/
+        dataset_url = self.dataset.get_absolute_url()  # /dataset/view/1/
         self.dataset_link_param.set_value(dataset_url)
         self.dataset_link_param.save()
 
@@ -294,7 +294,7 @@ class ParameterSetManagerTestCase(TestCase):
         self.assertTrue(psm.get_param("exp_link").link_gfk == self.exp)
 
         # Check link to dataset
-        dataset_url = self.dataset.get_absolute_url()  # /dataset/1/
+        dataset_url = self.dataset.get_absolute_url()  # /dataset/view/1/
         self.assertTrue(psm.get_param("dataset_link").string_value ==
                         dataset_url)
 
@@ -318,7 +318,7 @@ class ParameterSetManagerTestCase(TestCase):
         self.dataset_link_param2 = DatafileParameter(
             parameterset=self.datafileparameterset2,
             name=self.parametername_dataset_link)
-        # /dataset/1 - no trailing slash
+        # /dataset/view/1 - no trailing slash
         dataset_url = self.dataset.get_absolute_url()
         self.dataset_link_param2.set_value(dataset_url)
         self.dataset_link_param2.save()

--- a/tardis/urls/__init__.py
+++ b/tardis/urls/__init__.py
@@ -12,6 +12,7 @@ from django.views.static import serve
 from tardis.app_config import get_tardis_apps
 from tardis.app_config import format_app_name_for_url
 from tardis.tardis_portal.views import IndexView
+from tardis.apps.search.urls import urlpatterns as search_urls
 
 from tardis.tardis_portal.views.pages import site_routed_view
 from tardis.tardis_portal.views import upload
@@ -57,6 +58,8 @@ overridable_urls = [
 
 app_urls = []
 for app_name, app in get_tardis_apps():
+    if app_name == "search":
+        continue
     app_urls += [
         url(r'^%s/' % format_app_name_for_url(app_name),
             include('%s.urls' % app))
@@ -113,6 +116,9 @@ urlpatterns = [
 
     url(r'^upload/(?P<dataset_id>\d+)/$', upload,
         name='tardis.tardis_portal.views.upload'),
+
+    #Explicitly add search, to avoid including /apps/ in url
+    url(r'^search/', include(search_urls)),
 
     # Apps
     url(r'^apps/', include(app_urls)),

--- a/tardis/urls/ajax.py
+++ b/tardis/urls/ajax.py
@@ -36,7 +36,7 @@ from tardis.tardis_portal.views import (
 )
 
 json_urls = [
-    url(r'^dataset/(?P<dataset_id>\d+)$', dataset_json,
+    url(r'^dataset/view/(?P<dataset_id>\d+)/$', dataset_json,
         name='tardis.tardis_portal.views.dataset_json'),
     url(r'^experiment/(?P<experiment_id>\d+)/dataset/$',
         experiment_datasets_json,

--- a/tardis/urls/dataset.py
+++ b/tardis/urls/dataset.py
@@ -11,12 +11,12 @@ from tardis.tardis_portal.views import (
 )
 
 dataset_urls = [
-    url(r'^(?P<dataset_id>\d+)$', DatasetView.as_view(),
+    url(r'^view/(?P<dataset_id>\d+)/$', DatasetView.as_view(),
         name='tardis_portal.view_dataset'),
-    url(r'^(?P<dataset_id>\d+)/edit$', edit_dataset,
+    url(r'^edit/(?P<dataset_id>\d+)/$', edit_dataset,
         name='tardis.tardis_portal.views.edit_dataset'),
-    url(r'^(?P<dataset_id>\d+)/thumbnail$', dataset_thumbnail,
+    url(r'^thumbnail/(?P<dataset_id>\d+)/$', dataset_thumbnail,
         name='tardis.tardis_portal.views.dataset_thumbnail'),
-    url(r'^(?P<dataset_id>\d+)/checksums$', checksums_download,
+    url(r'^checksums/(?P<dataset_id>\d+)/$', checksums_download,
         name='tardis_portal.dataset_checksums'),
 ]

--- a/tardis/urls/project.py
+++ b/tardis/urls/project.py
@@ -17,9 +17,9 @@ project_urls = [
     #url(r'^view/(?P<project_id>\d+)$', ProjectDetails.as_view(),
     #    name='tardis_portal.views.react_project'),
 
-    url(r'^view/(?P<project_id>\d+)$', ProjectView.as_view(),
+    url(r'^view/(?P<project_id>\d+)/$', ProjectView.as_view(),
         name='tardis_portal.view_project'),
-    url(r'^edit/?P<project_id>\d+/$', edit_project,
+    url(r'^edit/(?P<project_id>\d+)/$', edit_project,
         name='tardis.tardis_portal.views.edit_project'),
     url(r'^create/$', create_project,
         name='tardis.tardis_portal.views.create_project')


### PR DESCRIPTION
**This PR homogenises the project/experiment/dataset/datafile urls, and updates relevant url calls.**

Model urls now take the form of:

> - MODEL/view/ID/
> - MODEL/edit/ID/
> - MODEL/thumbnail/ID/

and so on.URLs can handle missing backslashes from the end of the ID.

**This PR also removes "app" from the search URLs:** `IP/apps/search/ ->  IP/search/`
