### PR TITLE
Resolve Ticket IDS-356 User ACLs don't inherit from PI

### DIFF
--- a/tardis/apps/projects/api.py
+++ b/tardis/apps/projects/api.py
@@ -565,21 +565,24 @@ class ProjectResource(ModelResource):
                     project=project,
                     user=bundle.request.user,
                     canRead=True,
-                    canDownload=True,
+                    canDownload=False,
                     canWrite=True,
                     canDelete=True,
                     canSensitive=False,
-                    isOwner=True,
+                    isOwner=False,
                     aclOwnershipType=ProjectACL.OWNER_OWNED,
                 )
                 acl.save()
+                if bundle.request.user.id == project.principal_investigator.id:
+                    acl.isOwner = True
+                    acl.save()
                 if bundle.request.user.id != project.principal_investigator.id:
                     # and for PI
                     acl = ProjectACL(
                         project=project,
                         user=project.principal_investigator,
                         canRead=True,
-                        canDownload=True,
+                        canDownload=False,
                         canWrite=True,
                         canDelete=True,
                         canSensitive=False,


### PR DESCRIPTION
Added check in the Experiment/Dataset/Datafile APIs to make sure a PI user is created where the ACLs don't cascade.